### PR TITLE
array_declaration accept empty arrays

### DIFF
--- a/src/Grammar.pp
+++ b/src/Grammar.pp
@@ -102,7 +102,7 @@ object_access:
     ::dot:: <identifier> #attribute_access
 
 #array_declaration:
-    ::bracket_:: value() ( ::comma:: value() )* ::_bracket::
+    ::bracket_:: ( value() )? ( ::comma:: value() )* ::_bracket::
 
 #function_call:
     <identifier> ::parenthesis_::


### PR DESCRIPTION
```
tagList in []
```

does trigger a parsing error:
```
"Unexpected token "=" (identifier) at line 1 and column 16:
tagList in []
           ↑" at .../vendor/hoa/compiler/Llk/Parser.php line 1
```

We modify the grammar file to accept empty arrays