### PR TITLE
fix php 8.4 deprecations

### DIFF
--- a/src/Compiler/FileEvaluator.php
+++ b/src/Compiler/FileEvaluator.php
@@ -15,7 +15,7 @@ class FileEvaluator implements Evaluator
     /**
      * @param string $directory The directory in which the compiled executors are stored. Defaults to the system's temp directory.
      */
-    public function __construct($directory = null, Filesystem $fs = null)
+    public function __construct($directory = null, ?Filesystem $fs = null)
     {
         $this->directory = $directory ?: sys_get_temp_dir();
         $this->fs = $fs ?: new NativeFilesystem();

--- a/src/Exception/OperatorNotFoundException.php
+++ b/src/Exception/OperatorNotFoundException.php
@@ -8,7 +8,7 @@ class OperatorNotFoundException extends \RuntimeException
 {
     private $operator;
 
-    public function __construct(string $operator, $msg, \Exception $previous = null)
+    public function __construct(string $operator, $msg, ?\Exception $previous = null)
     {
         parent::__construct($msg, 0, $previous);
 


### PR DESCRIPTION
<details>
<summary>Details</summary>

```
FILE: /home/jravia/code/crm/vendor/mapado/rulerz/src/Compiler/FileEvaluator.php
------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------
 18 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be
    |         | explicitly nullable instead. Found implicitly nullable parameter: $fs.
    |         | (PHPCompatibility.FunctionDeclarations.RemovedImplicitlyNullableParam.Deprecated)
------------------------------------------------------------------------------------------------------------------------


FILE: /home/jravia/code/crm/vendor/mapado/rulerz/src/Exception/OperatorNotFoundException.php
------------------------------------------------------------------------------------------------------------------------
FOUND 0 ERRORS AND 1 WARNING AFFECTING 1 LINE
------------------------------------------------------------------------------------------------------------------------
 11 | WARNING | Implicitly marking a parameter as nullable is deprecated since PHP 8.4. Update the type to be
    |         | explicitly nullable instead. Found implicitly nullable parameter: $previous.
    |         | (PHPCompatibility.FunctionDeclarations.RemovedImplicitlyNullableParam.Deprecated)
------------------------------------------------------------------------------------------------------------------------
```

</details>